### PR TITLE
Proposal for adding Core Design's ACW and EDN file formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Contributions are also welcome!
   - [The Mark of Kri Engine](#the-mark-of-kri-engine)
 - [Core Design](#core-design)
   - [Tomb Raider Engine](#tomb-raider-engine-1996---2000)
+  - [Project Eden Engine](#project-eden-engine-2001)
   - [Herdy Gerdy Engine](#herdy-gerdy-engine-2002)
 - [Lucasfilm Games](templates/lucasfilm)
   - [Ares Engine](templates/lucasfilm/ares/ares.md)
@@ -144,6 +145,14 @@ was [Martian Gothic: Unification](https://www.mobygames.com/game/martian-gothic-
 
 ### Tomb Raider Engine (1996 - 2000)
 
+### Project Eden Engine (2001)
+
+Unaware of any proper name for this particular engine, though string in the executable say "engine_pc.lib".
+The engine was developed from scratch with a next-gen mindset that went away from the grid-based logic of Tomb Raider games.
+On the graphics side, the PC version included features like normal mapping, environment mapping, variable-rate animations
+and real-time morphing, which all used Direct3D 8's fixed-function pipeline.
+On the sound side, the most important feature was real-time environment-aware sound effects using DirectSound 8 and EAX 1.0.
+
 ### Herdy Gerdy Engine (2002)
 
 Unaware of any proper name for this particular engine.
@@ -151,16 +160,21 @@ There is some cross-over between this and the engine developed for the cancelled
 
 #### Games
 
+- [Project Eden (2001)](https://www.mobygames.com/game/project-eden)
 - [Herdy Gerdy (2002)](https://www.mobygames.com/game/herdy-gerdy)
 
 #### Formats
 
-| Name | Description                             | Status                      | URL                      |
-|------|-----------------------------------------|-----------------------------|--------------------------|
-| CLU  | Package format                          | **100%**                    | [Link](templates/core/core_clu.bt) |
-| HGT  | Texture format ('Herdy Gerdy Texture'?) | **50%** (container for BMP) | [Link](templates/core/core_hgt.bt) |
-| HGM  | Model format ('Herdy Gerdy Model'?)     | Pending                     | N/A                      |
-| GLV  | Level format ('Gerdy Level'?)           | Pending                     | N/A                      |
+| Name    | Description                             | Status                      | URL                      |
+|---------|-----------------------------------------|-----------------------------|--------------------------|
+| ACW     | Actor WAD format                        | **100%**                    | [Link](templates/core/core_acw.bt) |
+| EDN/PDN | Eden Level format                       | **100%**                    | [Link](templates/core/core_edn_pdn.bt) |
+| EDI/PDI | Eden Image format                       | Pending                     | N/A						 |
+| EDS/PDS | Eden Sound format                       | Pending                     | N/A						 |
+| CLU     | Package format                          | **100%**                    | [Link](templates/core/core_clu.bt) |
+| HGT     | Texture format ('Herdy Gerdy Texture'?) | **50%** (container for BMP) | [Link](templates/core/core_hgt.bt) |
+| HGM     | Model format ('Herdy Gerdy Model'?)     | Pending                     | N/A                      |
+| GLV     | Level format ('Gerdy Level'?)           | Pending                     | N/A                      |
 
 ## [Computer Artworks Ltd.](https://www.mobygames.com/company/computer-artworks-ltd)
 

--- a/README.md
+++ b/README.md
@@ -147,11 +147,20 @@ was [Martian Gothic: Unification](https://www.mobygames.com/game/martian-gothic-
 
 ### Project Eden Engine (2001)
 
-Unaware of any proper name for this particular engine, though string in the executable say "engine_pc.lib".
+Unaware of any proper name for this particular engine.
+
+#### Description
 The engine was developed from scratch with a next-gen mindset that went away from the grid-based logic of Tomb Raider games.
 On the graphics side, the PC version included features like normal mapping, environment mapping, variable-rate animations
-and real-time morphing, which all used Direct3D 8's fixed-function pipeline.
+and real-time morphing, which all used Direct3D 8.0a's fixed-function pipeline.
 On the sound side, the most important feature was real-time environment-aware sound effects using DirectSound 8 and EAX 1.0.
+
+#### Fun Facts
+- The game uses the GameSpy SDK for multi-player.
+- The game was statically linked with `engine_pc.lib` on PC and `engine_ps2.lib` on PS2.
+- PlayStation 2 version of the game was botched. It doesn't even use the integrated hardware vector units.
+- Some of the internal texture metadata uses the 'tga' extension which may suggest they used it as an intermediate format before conversion.
+- An official level editor was planned, but never released due to poor sales.
 
 ### Herdy Gerdy Engine (2002)
 

--- a/templates/core/core_acw.bt
+++ b/templates/core/core_acw.bt
@@ -1,0 +1,817 @@
+// Template created by Alan Moczulski
+/* Core Design, ACW format
+ *
+ * Usages:
+ * 	- Project Eden (2001, PC/PS2)
+ *
+ * Notes:
+ *	This file format holds mesh and animation data of characters
+ *  (such as Carter, Minoko, Andre, Amber, Dr. Molenski, Lucy, Death Head, Mutant Dog),
+ *  and props (like a door exploding, a desk falling down).
+ *  I think it was once a separate file with the extension "ACW", but because the EDN files
+ *  were designed to be self-contained it was ultimately decided by the developers to just
+ *  include it inside. I decided to split it since the BT script was getting really big,
+ *  and because it is self-sufficient.
+ *
+ *  An "actor" is composed of a mesh, a weighted skin and a set of animations related to it.
+ *  The animation itself is composed of keyframed positions (XYZ) and rotations (WXYZ quaternions)
+ *  and TCB control points (Kochanek-Bartels splines that allow for more control of
+ *  the interpolation, they define movement accentuation and flow).
+ *  These same curves can be exported from early versions of 3ds Max.
+ *
+ *  An "animation project" can be thought of like a universal animation clip that can be applied
+ *  to different "actors", given they share the same bone structure.
+ *
+ *  "Model morphing" is a feature of the game which enables seamless interpolation between
+ *  two different models (which, as a side effect, need to have the same amount of vertices).
+ *  This is used for human or dog actors morphing into monsters.
+ */
+ 
+ #include "core_eden_shared.bt"
+
+struct LoadCollision(uint32_t num_bones)
+{
+	struct CollisionComponent(uint32_t num_bones)
+	{
+		uint32_t a;
+		switch (a)
+		{
+		case 1:
+			struct Vector3 something;
+			float radius;
+			float bone_radiuses[num_bones];
+			break;
+		case 2:
+			float radius;
+			float bone_radiuses[num_bones];
+			break;
+		case 3:
+			float radius;
+			float bone_radiuses[num_bones];
+			float cylinderRadius;
+			float cylinderHeight;
+			break;
+		default:
+			break;
+		}
+	};
+	struct CollisionComponent collision(num_bones);
+};
+
+// defines a mesh and skin
+struct Model
+{
+	uint32_t type;
+	switch (type)
+	{
+	case 5:
+	{
+		uint32_t version; // should be 72
+
+		uint32_t someValue;
+		bool skinned;
+		uint32_t id;
+
+		uint32_t num_meshes;
+		struct Mesh meshes[num_meshes];
+
+		uint32_t num_bones;
+		uint32_t hkyFlag[num_bones];
+
+		struct SkinData
+		{
+			uint32_t vert_index;
+			uint32_t nverts;
+			
+			uint32_t num_weights;
+			float weights[num_weights];
+
+			struct Vector3 child_transform;
+			struct Vector3 parent_transform;
+		};
+		uint32_t num_skin_groups;
+		struct SkinData skin_data[num_skin_groups];
+
+		struct LoadCollision lc(num_bones);
+
+		struct ModelMorph
+		{
+			uint32_t a;
+			if (a == 1)
+			{
+				int32_t topologyKey;
+				uint32_t nverts;
+				uint16_t model2skin[nverts];
+				uint16_t skin2model[nverts];
+			}
+		};
+		bool uses_morph;
+		if (uses_morph)
+			struct ModelMorph morph;
+
+		uint32_t ntexture_id2index;
+		uint64_t texture_id2index[ntexture_id2index];
+
+		struct PRRemap
+		{
+			uint32_t buffer;
+			if (buffer == 1 || buffer == 2)
+			{
+				int size_unused;
+				uint8_t unused[size_unused];
+				int level;
+				int index;
+				int size_remap;
+				uint16_t remap[size_remap];
+
+				struct PRTable
+				{
+					uint32_t buffer;
+					if (buffer == 1)
+					{
+						int size;
+						int nindices;
+						int nlevels;
+						uint16_t table[size];
+						int size_vtable;
+						uint16_t vtable[size_vtable];
+					}
+				};
+				bool uses_reduction;
+				if (uses_reduction)
+					struct PRTable reduction;
+				
+				if (buffer == 2)
+				{
+					float falloff_near_size;
+					float falloff_far_size;
+					float falloff_power;
+				}
+			}
+		};
+		bool uses_remap;
+		if (uses_remap)
+			struct PRRemap remap;
+
+		break;
+	}
+	default:
+		char undefined[99999999];
+	}
+};
+
+// defines an orientation in 3D space
+struct Quaternion
+{
+	float w;
+	float x;
+	float y;
+	float z;
+};
+
+struct BodyLoc
+{
+	uint32_t version;
+	uint32_t num_body_locs;
+	struct BodyLocInternal(uint32_t version)
+	{
+		switch (version)
+		{
+		case 1:
+			uint32_t a;
+			struct Vector3 b;
+			uint32_t c;
+			uint32_t d;
+			uint32_t e;
+			break;
+		case 2:
+		case 4:
+			uint32_t a;
+			uint32_t b;
+			struct Vector3 c;
+			struct Vector3 d;
+			uint32_t e;
+			break;
+		case 3:
+			uint32_t a;
+			uint32_t b;
+			struct Vector3 c;
+			struct Quaternion orientation;
+			uint32_t d;
+			break;
+		default:
+			Printf("CRASH\n");
+			char crash[99999999];
+		}
+	};
+	struct BodyLocInternal bli(version)[num_body_locs];
+};
+
+struct sub_4D1580
+{
+	uint32_t version;
+	if (version == 1)
+	{
+		uint32_t smth;
+		uint32_t sz;
+		struct Internal
+		{
+			uint32_t unk;
+			bool t;
+			uint32_t a;
+			uint32_t b;
+			uint32_t c;
+			uint32_t d;
+		};
+		struct Internal array[sz];
+	}
+};
+
+struct sub_4D14D0
+{
+	uint32_t count;
+	struct sub_4D1580 s4[count];
+};
+
+struct Actor
+{
+	uint32_t type;
+	switch (type)
+	{
+	case 100:
+	{
+		uint32_t curr_model;
+		uint32_t num_flags;
+		char unfinished[99999999];
+		break;
+	}
+	case 109:
+	{
+		int32_t object_id;
+
+		uint32_t num_models;
+		struct Model models[num_models];
+		uint32_t curr_model;
+
+		uint32_t num_flags;
+		uint16_t flags[num_flags];
+
+		struct BodyLoc body_loc;
+		
+		struct ANIM_SET
+		{
+			int project_id;
+			int spec_id;
+		};
+		struct ANIM_SET bind_pose; // default character pose (usually T-pose)
+		struct ANIM_SET init_anim; // initial animation?
+		float velocity_ratio;
+		int32_t state_root_project;
+
+		uint32_t num_bones;
+		uint32_t bone_rel[num_bones];
+
+		struct sub_4D14D0 s4;
+
+		bool has_properties;
+		if (has_properties)
+		{
+			uint32_t version; // must be 72
+			struct OBJECT_PROPERTIES properties;
+		}
+
+		bool has_shadow;
+		break;
+	}
+	default:
+		char unfinished[99999999];
+	}
+};
+
+// a packed version of a keyframe
+struct PACKEDKEY
+{
+	int16_t time;
+	uint8_t tcb_index;
+	uint8_t data;
+	uint16_t index1;
+	uint16_t index2;
+	uint16_t index3;
+	uint16_t index4;
+};
+
+struct ANIM_POOL
+{
+	uint32_t smth;
+	uint32_t nkeys;
+	uint32_t nvectors;
+	uint32_t nquats;
+
+	struct PACKEDKEY keys[nkeys];
+	struct Vector3 vectors[nvectors];
+	struct Quaternion quats[nquats];
+};
+
+struct ANIM_SET
+{
+	int prj_id;
+	int spec_id;
+};
+
+struct EXPR
+{
+	uint32_t type; // warning: PS2 uses uint8_t
+};
+
+struct COND
+{
+	uint32_t count;
+	struct EXPR expressions[count];
+};
+
+struct TRANGE
+{
+	float st;
+	float et;
+};
+
+struct LINK_KEY
+{
+	struct TRANGE tr;
+	bool dynamic;
+	bool dyn_frames;
+	int16_t range_id;
+};
+
+struct LINK
+{
+	struct COND cond;
+	int state;
+	struct ANIM_SET linkto;
+	struct ANIM_SET via_link; // warning: PS2 code is different here
+	uint32_t num_keys;
+	struct LINK_KEY keys[num_keys];
+};
+
+struct RANGE_KEY
+{
+	struct TRANGE tr;
+};
+
+struct COMMAND
+{
+	uint32_t smth;
+
+	struct COND cond;
+
+	enum COMMAND_TYPE
+	{
+		IK_START,
+		IK_END,
+		EXTRA_ROTATION,
+		SPLIT_ANIM,
+		JOIN_ANIM,
+		HKY_INSERT,
+		HKY_REMOVE,
+		ACTION,
+		HKY_MORPH,
+		HKY_MORPH_REVERSE,
+		SOUND,
+		JOIN_HOLD,
+		TEXTURE_PROFILE,
+		CUTSCENE
+	};
+	enum COMMAND_TYPE type;
+
+	struct COMMAND_KEY
+	{
+		struct Default
+		{
+			bool active;
+			FSkip(3);
+			float time;
+		};
+		
+		enum COMMAND_TYPE type;
+		switch (type)
+		{
+		case 0:
+			struct Default def;
+			FSkip(4);
+			FSkip(4);
+			FSkip(4);
+			struct Vector3 a;
+			FSkip(4);
+			struct Vector3 b;
+			FSkip(4);
+			FSkip(4);
+			FSkip(4);
+			break;
+		case 1:
+		case 4:
+		case 11:
+			struct Default def;
+			FSkip(4);
+			FSkip(4);
+			break;
+		case 2:
+			struct Default def;
+			FSkip(4);
+			struct Vector3 smth;
+			break;
+		case 3:
+		case 7:
+		case 10:
+		case 12:
+			struct Default def;
+			FSkip(4);
+			break;
+		case 5:
+		case 6:
+			struct Default def;
+			FSkip(4);
+			FSkip(4);
+			FSkip(4);
+			break;
+		case 8:
+		case 13:
+			struct Default def;
+			FSkip(4);
+			FSkip(4);
+			FSkip(4);
+			FSkip(4);
+			break;
+		case 9:
+			struct Default def;
+			break;
+		default:
+			Printf("CRASH\n");
+			char crash[99999999];
+		};
+	};
+	uint32_t numKeys;
+	struct COMMAND_KEY keys[numKeys];
+};
+
+struct POSKEY
+{
+	float time;
+	float oodt;
+	int16_t tcb_index;
+	uint8_t pad0;
+	uint8_t pad1;
+	struct Vector3 p;
+	struct Vector3 c1;
+	struct Vector3 c2;
+	struct Vector3 c3;
+};
+
+struct ROTKEY
+{
+	float time;
+	float oodt;
+	int16_t tcb_index;
+	uint8_t linearity;
+	uint8_t padding;
+	struct Quaternion q;
+	struct Quaternion q0;
+	struct Quaternion q1;
+};
+
+// collection of position and rotation keyframes
+struct ANIM
+{
+	uint32_t num_pos_keys;
+	struct POSKEY pos_keys[num_pos_keys];
+	uint32_t num_rot_keys;
+	struct ROTKEY rot_keys[num_rot_keys];
+
+	// skip some old stuff, unused by the game
+	uint32_t local_4;
+	struct POSKEY skippable[local_4];
+};
+
+struct ANIM_PACKED
+{
+	int numPositionKeys;
+	uint32_t pos_key_index; // index into ANIM_POOL::keys
+
+	int numRotationKeys;
+	uint32_t rot_key_index; // index into ANIM_POOL::keys
+};
+
+// Kochanek-Bartels spline control point
+struct TCB
+{
+	float t;
+	float c;
+	float b;
+	float ease_to;
+	float ease_from;
+};
+
+struct FLOATKEY
+{
+	float time;
+	float oodt;
+	int16_t tcb_index;
+	int16_t padding;
+	float val;
+	float c1;
+	float c2;
+	float c3;
+};
+
+// defines a special animation
+struct SPECIAL_ANIM
+{
+	int id;
+	uint32_t type;
+	switch (type)
+	{
+	case 0:
+	{
+		struct ANIM anim;
+		break;
+	}
+	case 1:
+	{
+		// texture coordinates animation
+		struct ANIM_UV
+		{
+			uint32_t numU;
+			struct FLOATKEY u[numU];
+			uint32_t numV;
+			struct FLOATKEY v[numV];
+		};
+		struct ANIM_UV animUV;
+		break;
+	}
+	case 2:
+	{
+		// camera animation
+		struct ANIM_CAMERA
+		{
+			uint32_t numPositionKeys;
+			struct POSKEY pos[numPositionKeys];
+			uint32_t numTargetKeys;
+			struct POSKEY target[numTargetKeys];
+			uint32_t numRollKeys;
+			struct FLOATKEY roll[numRollKeys];
+			uint32_t numFOVKeys;
+			struct FLOATKEY fov[numFOVKeys];
+		};
+		struct ANIM_CAMERA animCamera;
+		break;
+	}
+	default:
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+};
+
+struct ANIMATION(uint32_t type, bool load_velocity)
+{
+	switch (type)
+	{
+	case 7:
+		bool packed;
+		uint32_t num_bones;
+
+		uint32_t version; // must be 2
+		if (version != 2)
+		{
+			Printf("CRASH\n");
+			char crash[99999999];
+		}
+
+		if (!packed)
+			struct ANIM bones[num_bones];
+		else
+			struct ANIM_PACKED packed_bones[num_bones];
+
+		float nframes;
+
+		// === curve control points ===
+		uint32_t ntcbs;
+		struct TCB tcbs[ntcbs];
+
+		bool hips_absolute;
+
+		uint32_t nspecials;
+		struct SPECIAL_ANIM specials[nspecials];
+
+		bool cylinder_height_set;
+		float cylinder_height;
+
+		if (load_velocity)
+		{
+			if (!packed)
+				struct ANIM velocity;
+			else
+				struct ANIM_PACKED velocity;
+		}
+
+		break;
+	default:
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+};
+
+struct ALT_ANIM
+{
+	bool original;
+	struct COND cond;
+	struct ANIMATION anim(7, 1);
+};
+
+struct ANIM_SPEC
+{
+	uint32_t smth;
+	switch (smth)
+	{
+	case 7:
+	{
+		int state;
+		uint8_t prop_to_bind;
+		
+		struct ANIM_SET jumpto;
+		float jumpto_time;
+
+		uint32_t num_ranges;
+		struct RANGE_KEY range[num_ranges];
+
+		uint32_t num_links;
+		struct LINK links[num_links];
+
+		uint32_t num_commands;
+		struct COMMAND commands[num_commands];
+
+		uint32_t num_alt_anims;
+		struct ALT_ANIM altAnims[num_alt_anims];
+
+		uint8_t type;
+
+		break;
+	}
+	default:
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+};
+
+struct SPLIT_DEF
+{
+	uint32_t local_8;
+	if (local_8 == 1)
+	{
+		uint32_t splitID;
+		uint32_t num_bones;
+		uint8_t bones[num_bones];
+	}
+};
+
+struct AnimationProject
+{
+	int32_t read_num_specs;
+	local int32_t num_specs;
+	local uint32_t local_20;
+	if (read_num_specs < 0)
+	{
+		num_specs = -read_num_specs;
+		uint32_t read_local;
+		local_20 = read_local;
+	}
+	else
+	{
+		num_specs = read_num_specs;
+		local_20 = 1;
+	}
+
+	switch (local_20)
+	{
+	case 4:
+	{
+		bool use_anim_pool;
+		if (use_anim_pool)
+			struct ANIM_POOL anim_pool;
+
+		struct ANIM_SPEC specs[num_specs];
+		
+		uint32_t num_split_defs;
+		struct SPLIT_DEF splits[num_split_defs];
+
+		uint32_t project_id;
+		break;
+	}
+	default:
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+};
+
+struct Cutscene
+{
+	uint32_t smth;
+	uint32_t anim_type;
+	if (anim_type != 7)
+	{
+		Printf("Crash!\n");
+		char crash[99999999];
+	}
+	if (smth == 1) // TODO: never hit???
+	{
+		uint32_t a;
+		struct ANIMATION anim(anim_type, 0);
+		uint32_t count;
+		struct SMTH
+		{
+			uint32_t l;
+			uint64_t m;
+		};
+		struct SMTH arr[count];
+	}
+	else if (smth == 2)
+	{
+		uint32_t a;
+		uint32_t b;
+		struct ANIMATION anim(anim_type, 0);
+		uint32_t count;
+		struct SMTH
+		{
+			uint32_t l;
+			uint64_t m;
+		};
+		struct SMTH arr[count];
+	}
+};
+
+struct ACWTexture
+{
+	uint32_t num_frames;
+	struct Frame frames[num_frames];
+
+	enum <uint32_t> Usage
+	{
+		NONE,
+		DIFFUSE,
+		LIGHT,
+		BUMP,
+		GLOSS,
+		ENVIRONMENT_MAP,
+		SPRITE,
+		EMISSIVE,
+		TEXT,
+		IMAGE
+	};
+	
+	if (num_frames > 0)
+	{
+		enum Usage usage;
+		bool is_transparent;
+		bool allow_mipmaps;
+		bool is_emissive;
+	}
+};
+
+struct ActorWad
+{
+	char magic[14]; // should be "ACW Actor Wad"
+	
+	uint32_t version; // should be 9
+	if (version != 9)
+	{
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+
+	uint32_t num_actors;
+	uint32_t num_animation_projects;
+	uint32_t num_cutscenes;
+	uint32_t num_textures;
+	uint32_t num_surface_materials;
+	uint32_t num_surface_properties;
+
+	Printf("Reading actors...\n");
+	struct Actor actors[num_actors];
+
+	Printf("Reading animations...\n");
+	struct AnimationProject projects[num_animation_projects];
+
+	Printf("Reading cutscenes...\n");
+	struct Cutscene cutscenes[num_cutscenes];
+
+	int32_t texture_version;
+	if (texture_version != 5)
+	{
+		Printf("CRASH\n");
+		char crash[99999999];
+	}
+	
+	Printf("Reading actors tex&mat...\n");
+	struct ACWTexture textures[num_textures];
+	struct SurfaceMaterial surface_materials[num_surface_materials];
+	struct SurfaceProperty surface_properties[num_surface_properties];
+};
+ 

--- a/templates/core/core_eden_shared.bt
+++ b/templates/core/core_eden_shared.bt
@@ -1,0 +1,257 @@
+// Template created by Alan Moczulski
+/*
+ * Core Design, Project Eden shared definitions
+ */
+
+#ifndef CORE_EDEN_SHARED
+#define CORE_EDEN_SHARED
+
+typedef uint8_t bool;
+
+struct Vector3
+{
+	float x;
+	float y;
+	float z;
+};
+
+// a vertex that is shared by multiple faces
+struct Corner
+{
+	uint16_t vertex_index;
+	uint16_t padding;
+	uint32_t color;							// rgb perhaps?
+	float textureUV[2];
+	float lightmapUV[2];
+};
+
+struct Hull
+{
+	uint32_t n;
+	if (n == 0)
+	{
+		int32_t charC;
+		struct Vector3 vec0;
+		struct Vector3 vec1;
+		struct Vector3 normal;
+		struct Vector3 vec3;
+		uint32_t num_vertices;
+		struct Vector3 vertices[num_vertices];
+	}
+};
+
+struct Face
+{
+	int32_t surface_property_index;			// index in EDNFile's surface_properties
+
+	int32_t index;							// is a lightmap index if this Face does not belong to an Actor
+											// is a material index if this Face belongs to an Actor
+
+	uint32_t face_type;						// 3="triangle", 4="quad", 6="2 triangles"
+
+	uint32_t num_vertices;
+	uint16_t vertex_indices[num_vertices];
+	
+	uint16_t num_i;
+	int32_t mi[num_i];
+	
+	uint32_t num_global_i;
+	int16_t globalI[num_global_i];			// corner indices?
+
+	struct Hull hull;
+
+	struct Vector3 normal;							// normal of the face (can be used for per-vertex flat shading)
+	struct Vector3 min_extent;
+	struct Vector3 max_extent;
+	
+	bool unk5;
+	if (unk5)
+	{
+		int16_t unk6;
+		int16_t unk7;
+		int16_t unk6array[unk6];
+		int16_t unk7array[unk7];
+
+		int16_t unk8;
+		int unk8array[unk8];
+	}
+};
+
+struct Recursive
+{
+	bool read;
+	if (read)
+	{
+		char smth[9];
+
+		int16_t unk10;
+		int16_t arr[unk10];
+
+		struct Recursive r1;
+		struct Recursive r2;
+	}
+};
+
+struct Mesh
+{
+	uint32_t name_length;
+	char name[name_length];
+	
+	int32_t flags;										// used to specify smooth or flat normals (default is smooth)
+	
+	// === vertex data ===
+	uint32_t num_verts;									// it is possible for a Room not to have any vertices,
+														// which is weird but it has happened a few times during my analysis
+	struct Vector3 vertex_positions[num_verts];			// array of vertex positions in model-space
+	struct Vector3 vertex_normals[num_verts];			// array of normalised, smooth vertex normals in model-space
+	
+	uint32_t unk;
+	
+	// === bounding box ===
+	struct Vector3 min_extent;
+	struct Vector3 max_extent;
+
+	// === topology data ===
+	uint32_t num_corners;
+	if (num_corners == 0)
+		uint32_t unk1;
+	else
+	{
+		struct Corner corners[num_corners];
+		uint32_t num_faces;
+		struct Face faces[num_faces];
+	}
+	
+	struct TEXTURE_BASIS
+	{
+		struct Vector3 axis_u;							// tangent?
+		struct Vector3 axis_v;							// bitangent?
+		struct Vector3 axis_w;							// normal?
+	};
+	int num_corner_texture_basis;
+//	assert(corner_texture_basis == num_corners);
+	struct TEXTURE_BASIS corner_texture_basis[num_corner_texture_basis];
+
+	bool has_locator;
+	if (has_locator)
+		char unkarray[24];
+
+	// === HIT_DATA (collision?) ===
+	int16_t unk5;
+	if (unk5)
+		struct Recursive r;
+};
+
+struct OBJECT_PROPERTIES
+{
+	struct OBJECT_PROPERTY
+	{
+		uint32_t type;
+		uint32_t number;
+		uint32_t length;
+		char string[length];
+	};
+	uint32_t numProperties;
+	struct OBJECT_PROPERTY properties[numProperties];
+};
+
+struct Frame
+{
+	int32_t v;									// usually 131200 or 131328
+	local int16_t width = v & 0xFFFF;
+	int32_t height;
+	int32_t pixel_size;
+	int32_t unk;
+
+	local int16_t shifted = v >> 16;
+	local uint32_t size;
+	if (shifted <= 0)
+		size = width * height * pixel_size;		// compute size
+	else
+	{
+		uint32_t read_size;
+		size = read_size;						// read size
+	}
+
+	uint32_t skipped[7];						// some DDS specific stuff
+	uint32_t dxt_identifier;					// equal to '1TXD' or '3TXD' or '5TXD'
+
+	char data[size];							// actual texture data
+
+	if (shifted > 1)
+	{
+		bool has_lower_mip;
+		if (has_lower_mip)
+			struct Frame mip;					// read smaller mip
+	}
+};
+
+struct SurfaceMaterial
+{
+	uint16_t version;
+
+	bool used;
+	if (used)
+	{
+		if (version > 5)
+			bool clamp;
+
+		if (version < 3)
+		{
+			int32_t texture_index_diffuse;			// -1 if not used
+			int32_t texture_index_normal;			// same...
+			int32_t texture_index_gloss;
+			int32_t texture_index_env;
+
+			if (version > 1)
+				int32_t texture_index_emissive;
+		}
+
+		if (version > 2)
+		{
+			uint32_t num_textures; // is equal to 5 most of the time (diffuse, normal, gloss, env, emissive)
+			int32_t texture_index_array[num_textures];
+
+			if (version < 5)
+				uint8_t env_strength;
+			if (version > 4)
+				uint8_t emissive_strength;
+		}
+	}
+};
+
+struct SurfaceProperty
+{
+	uint16_t version;							// format version
+	uint16_t nmaterials;
+	if (nmaterials)
+	{
+		uint16_t pmaterials[nmaterials];		// indices of materials this surface property applies to
+		uint16_t selected_material;
+	}
+
+	// === texture color modulation (multiplication) ===
+	bool enable_modulate;
+	if (version > 2 || enable_modulate)
+	{
+		uint8_t mod_r;
+		uint8_t mod_g;
+		uint8_t mod_b;
+		uint8_t mod_a;
+	}
+
+	// === dynamic texture translation ===
+	bool enable_offset_uv;
+	if (version > 2 || enable_offset_uv)
+	{
+		float offset_u;
+		float offset_v;
+	}
+
+	if (version > 1)
+		bool unique;
+	if (version > 3)
+		uint16_t surface_type;					// perhaps this defines the type of sound the surface produces (wood, metal)?
+};
+
+#endif

--- a/templates/core/core_edn_pdn.bt
+++ b/templates/core/core_edn_pdn.bt
@@ -29,8 +29,9 @@
  *  I haven't figured out which yet. I have a hint though: the decompression function
  *  uses a 1024-byte table allocated on the stack. I found a text reference to "LZJAT Encoder"
  *  inside the game executable, but I couldn't find any info on it online. It doesn't exist.
- *  As a temporary solution, I provided x86 assembly source inside "lzjat_decode.s" and a
- *  console program inside "edn_decompress.c" that uses it, which you can use to decompress EDNs.
+ *  As a temporary solution, I wrote a decompression program which you can find inside
+ *  the "edn_decompression" folder. It includes x86 assembly source "lzjat_decode.s" and a
+ *  console-mode program "main.c" that uses it.
  *  As a side note, PDN files are never compressed (since that would make CD streaming harder).
  *
  *  === Header ===

--- a/templates/core/core_edn_pdn.bt
+++ b/templates/core/core_edn_pdn.bt
@@ -1,0 +1,894 @@
+// Template created by Alan Moczulski
+/* Core Design, EDN/PDN format
+ *
+ * Usages:
+ * 	- Project Eden (2001, PC (EDN) / PS2 (PDN))
+ *
+ * Notes:
+ *  This format describes a level, including its geometry, entities, lights, triggers,
+ *  textures, characters, animations and AI navigation paths.
+ *  EDN is used by the PC version, PDN is used by the PS2 version, they differ slightly.
+ *  I will indicate the differences whenever applicable.
+ *
+ *  Project Eden contains around 30 such files, where 11 are meant to be
+ *  played in single-player mode, 22 as both single-player and multi-player,
+ *  6 as non-playable inter-level cutscenes and 1 used for the main menu background.
+ *
+ *  === Modularity ===
+ *  The format is very self-contained in the sense that everything is
+ *  stored inside the EDN file so that it is fully standalone -- even the 4 main protagonists are
+ *  duplicated for every level. On first thought, this would seem like a waste of disk space but
+ *  such an approach allows easy modding by the players. "Room Editor II" was created for that
+ *  purpose, similarly to the Tomb Raider level editing tools.
+ *  "Room Editor II" was never relased to the public because of poor sales, only thing left
+ *  of it are screenshots.
+ *
+ *  === Compression ===
+ *  Some of these level files are compressed (this is indicated by the string "COMP"
+ *  in the first bytes of the file), using a variant of the LZ algorithm, though
+ *  I haven't figured out which yet. I have a hint though: the decompression function
+ *  uses a 1024-byte table allocated on the stack. I found a text reference to "LZJAT Encoder"
+ *  inside the game executable, but I couldn't find any info on it online. It doesn't exist.
+ *  As a temporary solution, I provided x86 assembly source inside "lzjat_decode.s" and a
+ *  console program inside "edn_decompress.c" that uses it, which you can use to decompress EDNs.
+ *  As a side note, PDN files are never compressed (since that would make CD streaming harder).
+ *
+ *  === Header ===
+ *  Each of the level files are identified by a version number (demo and retail both use 72)
+ *  and a char[4] ID, not by their file name.
+ *  This means that the storyline and flow of the game can be altered by creating new
+ *  intermediate levels without the game even noticing. No level file names
+ *  are hardcoded in the executable, except the main menu background "titlebackdrop.EDN".
+ *  Other useful information is present in the header, such as the max number of players
+ *  that are able to play the level in multi-player mode and the ID of the current and next level.
+ *
+ *  The game contains code to load very early versions (< 72) of the format, although it has been
+ *  disabled using an if-statement that has not been optimised away (thanks VC6!).
+ *  That made reverse-engineering much more complicated though. The game code looks like
+ *  a labyrinth of nested switch statements.
+ *
+ *  === The Actor Wad ===
+ *  Every file contains at some point a chunk of data that can be easily recognised
+ *  by the follwing text: "ACW Actor Wad".
+ *  You can find more information on it in the corresponding core_acw.bt file.
+ *
+ *	=== Textures & Materials ===
+ *	The next piece of data contains texture and material information.
+ *  A texture can consist of one or multiple frames if it is animated.
+ *  The most common texture dimensions used by the game are 64x64, 128x128 and 256x256.
+ *	A material can reference up to 5 multiple textures:
+ *  diffuse map, normal map, gloss map, environment map, emissive map.
+ *  It is quite impressive for a game from 2001 to incorporate such features,
+ *  even if these names mean something different nowadays than what the devs had in mind.
+ */
+
+#include "core_eden_shared.bt"
+#include "core_acw.bt"
+
+struct Header
+{
+	uint32_t version;			// always equal to 72, or 'PMOC' if compressed
+	if (version != 72)
+	{
+		// the file needs to be decompressed first, the parsing cannot continue
+		char invalid_version[99999999];
+	}
+
+	int32_t level_index;		// a number from 0 to 11, indicating the single-player level order
+								// although can also be -1, in this case it is considered to be a multi-player level
+	uint32_t num_players;		// max player count allowed if multi-player level
+	uint32_t flags;				// ???
+	char level_id[4];			// current level ascii identifier
+	char next_level_id[4];		// next level ascii identifier
+};
+
+struct WP_ANIM
+{
+	struct WP_POS
+	{
+		float time;
+		float time_mod;
+		int wp;
+		int last_wp;
+		int link;
+	};
+	
+	// waypoint
+	struct WP
+	{
+		enum <uint32_t> WPS_STATE
+		{
+			WPS_SYSTEM = 0,
+			WPS_TRIGGER = 1,
+			WPS_TRIGGEROFF = 2,
+			WPS_OFF = 3,
+			WPS_ON = 4,
+			WPS_CLOSED = 5,
+			WPS_OPEN = 6,
+			WPS_LEVEL1 = 7,
+			WPS_LEVEL2 = 8,
+			WPS_LEVEL3 = 9,
+			WPS_LEVEL4 = 10,
+			WPS_WAITING = 11,
+			WPS_READY = 12,
+			WPS_MOVING = 13,
+			WPS_BROKEN = 14,
+			WPS_NUMBER = 15
+		};
+		
+		struct WP_LINK
+		{
+			enum WPS_STATE state;
+			bool check_conditions;
+			bool hold;
+			bool gravity;
+
+			struct WP_CONDITION
+			{
+				uint32_t state_index;
+			};
+			uint32_t nconditions;
+			struct WP_CONDITION conditions[nconditions];
+
+			int next;
+			float nframes;
+			float ease_to;
+			float ease_from;
+		};
+		
+		enum WPS_STATE system_state;
+		uint32_t nlinks;
+		struct WP_LINK links[nlinks];
+	};
+	uint32_t nwaypoints;
+	struct WP waypoints[nwaypoints];
+
+	int wp_pos_wp; // ???
+
+	float accdec;
+	bool ai_network;
+	bool no_deviation;
+	
+	struct WL(uint32_t& type, uint32_t nwaypoints)
+	{
+		uint32_t read_type;
+		type = read_type;
+		switch (type)
+		{
+		case 0:
+			break;
+		case 1:
+		{
+			struct WP_OBJECT_ANIM
+			{
+				bool invisible;
+				struct Vector3 position;
+				struct Vector3 rotation;
+				uint32_t location;
+				float spin;
+			};
+			struct WP_OBJECT_ANIM anim[nwaypoints];
+			break;
+		}
+		case 2:
+		{
+			uint32_t propertyIndex;
+			struct WP_TEXTURE_ANIM
+			{
+				uint32_t material;
+				float u_offset;
+				float v_offset;
+				float roll;
+				float r;
+				float g;
+				float b;
+			};
+			struct WP_TEXTURE_ANIM anim[nwaypoints];
+			break;
+		}
+		case 3:
+		{
+			struct WP_SOUND_ANIM
+			{
+				uint32_t arrivalSoundID;
+				uint32_t leavingSoundID;
+			};
+			struct WP_SOUND_ANIM anim[nwaypoints];
+			break;
+		}
+		case 4:
+		{
+			struct WP_CHARACTER_ANIM
+			{
+				uint32_t type;
+				uint32_t speed;
+				uint32_t state;
+				uint16_t stateData;
+				bool joinable;
+			};
+			struct WP_CHARACTER_ANIM anim[nwaypoints];
+			break;
+		}
+		default:
+			char crash[99999999];
+		}
+	};
+	struct WL wls[0]; // we don't know the size yet
+	local uint32_t type = 1; // so that we enter the while-loop
+	while (type)
+		ArrayExtend(wls, 1, type, nwaypoints);
+};
+
+struct Light
+{
+	enum Type
+	{
+		Point,
+		Fog,
+		Dynamic,
+		Spot,
+		FogPlane,
+		DynamicSpot
+	};
+	enum Type type;
+	struct Vector3 position;				// world-space position
+	int32_t rgb_color[3];					// each channel [0;255]
+	float intensity;						// [0;1]
+	float falloff;
+	float falloff_cos;
+	float hotspot;
+	float hotspot_cos;
+	struct Vector3 direction;				// local-space direction
+	float ambient;							// [0;1]
+};
+
+struct SubObjectsLoad
+{
+	uint32_t count;
+	struct Internal
+	{
+		uint32_t index;
+		struct SubObjectsLoad sol; // recursion
+	};
+	struct Internal internal[count];
+};
+
+struct TriggerDataLoad
+{
+	char unk1[7];
+	int unk2;
+	int32_t arr[unk2];
+	char t[16];
+};
+
+struct Trigger
+{
+	uint32_t name_length;
+	char name[name_length];
+
+	// === bounding box ===
+	struct Vector3 min_extent;
+	struct Vector3 max_extent;
+
+	int32_t unk0;
+	int32_t unk1;
+	int32_t unk2;
+
+	bool b1;
+	if (b1)
+		struct TriggerDataLoad tdl;
+
+	int32_t unk3;
+	int32_t num;
+	int32_t unkarray[num];
+};
+
+struct Room
+{
+	// === transformation data ===
+	float scale;
+	struct Vector3 position;							// world-space position
+	
+	// === sound data ===
+	int32_t ambient_sound;
+	struct EnvironmentSoundData
+	{
+		uint16_t type;									// defines room type (big, small), used for reverb effects
+		uint8_t delay;
+		uint8_t feedback;
+	};
+	struct EnvironmentSoundData env_sound_data;
+	
+	// === lighting data ===
+	uint32_t num_lights;
+	uint32_t light_indices[num_lights];					// indices to EDNFile's lights array
+	
+	struct SubObjectsLoad sol;
+	
+	// === interaction data ===
+	uint32_t num_triggers;
+	struct Trigger triggers[num_triggers];
+	
+	// === AI navigation path data ===
+	uint32_t num_ai_networks;
+	uint32_t ai_network_indices[num_ai_networks];		// indices to EDNFile's ai_networks array
+	
+	// === visibility optimisation data ===
+	uint32_t num_visible_rooms;
+	uint32_t visible_room_indices[num_visible_rooms];	// indices to EDNFile's rooms array
+	
+	// === geometry data ===
+	struct Mesh mesh;
+};
+
+struct Color32
+{
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+	uint8_t a;
+};
+
+struct Emitter
+{
+	uint32_t name_length;
+	char name[name_length];
+//	Printf("Read emitter %s.\n", name);
+
+	bool color_addition;									// whether to multiply by environment color?
+
+	float gravity;
+
+	int ttt;
+	int rate;
+	float life_time;										// how long each particle lives
+	int timer;												// current time accumulator?
+	int pause;
+
+	struct Color32 start_color;
+	struct Color32 end_color;
+
+	float start_scale;
+	float end_scale;
+
+	float speed;
+	float scatter;
+	float area_x;
+	float area_y;
+
+	float spin;
+	uint32_t thing2;
+	int texture_index;
+
+	int particle_type;
+	int num_initial_particles;
+
+	uint32_t num_drawable_indices;
+	uint32_t drawable_indices[num_drawable_indices];
+
+	float particle_length;
+
+	bool deflection_plane_active;
+	uint32_t a;
+	struct Vector3 b;
+	float deflection_plane_reduction;
+	
+	float speed_random;
+};
+
+struct VALUE_CONTROL_FLOAT
+{
+	struct VALUE_INSTANCE
+	{
+		float value;
+		float time;
+	};
+	uint32_t num_values;
+	struct VALUE_INSTANCE values[num_values];
+	uint8_t flag_random;
+};
+
+struct VALUE_CONTROL_U8
+{
+	struct VALUE_INSTANCE
+	{
+		uint8_t value;
+		float time;
+	};
+	uint32_t num_values;
+	struct VALUE_INSTANCE values[num_values];
+	uint8_t flag_random;
+};
+
+struct STREAMER_EFFECT_DATA
+{
+	uint32_t index_surface_property;
+	uint16_t count_segments;
+	float wrap_u;
+	float wrap_v;
+	bool use_surface_material_list_to_animate;
+	bool blend_additive;
+	bool face_camera;
+	bool double_sided;
+	struct VALUE_CONTROL_FLOAT radius_modulate;
+	struct VALUE_CONTROL_FLOAT edge_wibble_frequency;
+	struct VALUE_CONTROL_FLOAT edge_wibble_amplitude;
+	struct VALUE_CONTROL_FLOAT point_wibble_frequency;
+	struct VALUE_CONTROL_FLOAT point_wibble_amplitude;
+	struct VALUE_CONTROL_FLOAT radius;
+	struct VALUE_CONTROL_FLOAT offset_u;
+	struct VALUE_CONTROL_U8 colour_a_start;
+	struct VALUE_CONTROL_U8 colour_r_start;
+	struct VALUE_CONTROL_U8 colour_g_start;
+	struct VALUE_CONTROL_U8 colour_b_start;
+	struct VALUE_CONTROL_U8 colour_a_end;
+	struct VALUE_CONTROL_U8 colour_r_end;
+	struct VALUE_CONTROL_U8 colour_g_end;
+	struct VALUE_CONTROL_U8 colour_b_end;
+	float initial_length;
+};
+
+struct Entity // I gave this structure a more meaningful name since the game calls this "spot effect", very oddly
+{
+	uint32_t name_length;
+	char name[name_length];
+//	Printf("Read entity %s.\n", name);
+
+	enum <uint16_t> Type
+	{
+		NONE = 0,
+		SHOCK_SPHERE,
+		LAYERED_BILLBOARD,
+		MESH,
+		MULTI,
+		EMITTER,
+		LIGHT,
+		HEMI_SPHERE,
+		SOUND,
+		TOGGLE_LIGHTMAP,				// used whenever the player brings power to a dark room
+		STREAMER,						// a quad with a scrolling texture (used for the FlyCam)
+		TEXTURE_HOLDER,
+		SPAWNER,						// usually used for spawning monsters
+		CAMERA_SHAKE,					// used to shake the player's camera
+		CUTSCENE,
+		DISC,
+		CYLINDER,
+		TRAILER,
+		LIGHT_VOLUME,
+		DAMAGE_SPHERE
+	};
+	enum Type type;
+
+	switch (type)
+	{
+	case NONE:
+		break;
+	case SHOCK_SPHERE:
+		float life_max;
+		uint32_t index_surface_property;
+		bool use_surface_material_list_to_animate;
+		bool blend_additive;
+		struct VALUE_CONTROL_FLOAT size;
+		struct VALUE_CONTROL_U8 colour_a;
+		struct VALUE_CONTROL_U8 colour_r;
+		struct VALUE_CONTROL_U8 colour_g;
+		struct VALUE_CONTROL_U8 colour_b;
+		bool looping;
+		uint32_t life_loop;
+		break;
+	case LAYERED_BILLBOARD:
+		uint32_t ua;
+		uint32_t ub;
+		uint32_t uc;
+		bool ba;
+		bool bb;
+		bool bc;
+		bool bd;
+		bool be;
+
+		struct VALUE_CONTROL_FLOAT a;
+		struct VALUE_CONTROL_FLOAT b;
+		struct VALUE_CONTROL_FLOAT c;
+
+		struct VALUE_CONTROL_U8 d;
+		struct VALUE_CONTROL_U8 e;
+		struct VALUE_CONTROL_U8 f;
+
+		struct VALUE_CONTROL_U8 g;
+		struct VALUE_CONTROL_FLOAT h;
+
+		bool looping;
+		uint32_t life_loop;
+		break;
+	case MESH:
+		float life_max;
+		uint32_t drawable_number;
+		bool smth0;
+		struct VALUE_CONTROL_FLOAT size;
+		struct VALUE_CONTROL_U8 colour_a;
+		struct VALUE_CONTROL_U8 colour_r;
+		struct VALUE_CONTROL_U8 colour_g;
+		struct VALUE_CONTROL_U8 colour_b;
+		bool looping;
+		uint32_t lifeLoopStart;
+		uint32_t lifeLoopEnd;
+		uint32_t indexSurfaceProperty;
+		break;
+	case MULTI: // this defines an explosion, I think
+		uint16_t count;
+		uint32_t arr[count];
+		break;
+	case EMITTER:
+		uint32_t a;
+		uint32_t b;
+		bool c;
+		uint32_t d;
+		break;
+	case LIGHT:
+		FSkip(4);
+		FSkip(1);
+		FSkip(4);
+		
+		struct VALUE_CONTROL_FLOAT a;
+		struct VALUE_CONTROL_FLOAT b;
+		
+		struct VALUE_CONTROL_U8 c;
+		struct VALUE_CONTROL_U8 d;
+		struct VALUE_CONTROL_U8 e;
+
+		FSkip(9); // 4,1,4?
+
+		struct VALUE_CONTROL_U8 f;
+		
+		struct VALUE_CONTROL_FLOAT g;
+		break;
+	case HEMI_SPHERE:
+		float life_max;
+		uint32_t index_surface_property;
+		bool use_surface_material_list_to_animate;
+		bool blend_additive;
+		float angle_start;
+		float angle_end;
+		float wrap_u;
+		float wrap_v;
+		uint16_t count_rings;
+		uint16_t count_segments;
+		bool double_sided;
+		bool facing;
+		bool looping;
+		struct VALUE_CONTROL_FLOAT size;
+		struct VALUE_CONTROL_U8 colour_a;
+		struct VALUE_CONTROL_U8 colour_r;
+		struct VALUE_CONTROL_U8 colour_g;
+		struct VALUE_CONTROL_U8 colour_b;
+		struct VALUE_CONTROL_U8 colour_angle_a;
+		struct VALUE_CONTROL_U8 colour_angle_r;
+		struct VALUE_CONTROL_U8 colour_angle_g;
+		struct VALUE_CONTROL_U8 colour_angle_b;
+		uint32_t lifeLoop;
+		break;
+	case SOUND:
+		uint32_t a;
+		bool b;
+		uint32_t c;
+		uint16_t d;
+		bool e;
+		break;
+	case TOGGLE_LIGHTMAP:
+		uint32_t thing;
+		break;
+	case STREAMER:
+		float lifeMax;
+		bool looping;
+		bool useMatchingArray;
+		struct VALUE_CONTROL_FLOAT arrayWibbleAmplitude;
+		struct VALUE_CONTROL_FLOAT arrayWibbleFrequency;
+		struct STREAMER_EFFECT_DATA data;
+		uint32_t lifeLoop;
+		break;
+	case TEXTURE_HOLDER:
+		uint32_t count;
+		uint32_t arr[count];
+		break;
+	case SPAWNER:
+		uint32_t a;
+		uint32_t b;
+		uint32_t c;
+		uint32_t d;
+		bool bb;
+		break;
+	case CAMERA_SHAKE:
+		float life_max;
+		uint8_t looping;
+		uint8_t scale_with_distance;
+		uint8_t verticle_rectify;
+		struct VALUE_CONTROL_FLOAT radius;
+		struct VALUE_CONTROL_FLOAT center_strength;
+		struct VALUE_CONTROL_FLOAT center_random;
+		struct VALUE_CONTROL_FLOAT verticle_amplitude;
+		struct VALUE_CONTROL_FLOAT verticle_frequency;
+		struct VALUE_CONTROL_FLOAT tilt_angle;
+		uint32_t life_loop;
+		break;
+	case CUTSCENE:
+		uint32_t id;
+		break;
+	case DISC:
+		float life_max;
+		uint32_t index_surface_property;
+		bool use_surface_material_list_to_animate;
+		bool blend_additive;
+		float wrap_u;
+		float wrap_v;
+		uint16_t count_rings;
+		uint16_t count_segments;
+		bool double_sided;
+		bool facing;
+		bool looping;
+		struct VALUE_CONTROL_FLOAT radius_inner;
+		struct VALUE_CONTROL_FLOAT radius_outter;
+		struct VALUE_CONTROL_U8 colour_a;
+		struct VALUE_CONTROL_U8 colour_r;
+		struct VALUE_CONTROL_U8 colour_g;
+		struct VALUE_CONTROL_U8 colour_b;
+		struct VALUE_CONTROL_U8 colour_radius_a;
+		struct VALUE_CONTROL_U8 colour_radius_r;
+		struct VALUE_CONTROL_U8 colour_radius_g;
+		struct VALUE_CONTROL_U8 colour_radius_b;
+		uint32_t lifeLoop;
+		break;
+	case CYLINDER:
+		float life_max;
+		uint32_t index_surface_property;
+		bool use_surface_material_list_to_animate;
+		bool blend_additive;
+		float wrap_u;
+		float wrap_v;
+		uint16_t count_rings;
+		uint16_t count_segments;
+		bool double_sided;
+		bool facing;
+		bool looping;
+		struct VALUE_CONTROL_FLOAT size;
+		struct VALUE_CONTROL_U8 colour_a;
+		struct VALUE_CONTROL_U8 colour_r;
+		struct VALUE_CONTROL_U8 colour_g;
+		struct VALUE_CONTROL_U8 colour_b;
+		struct VALUE_CONTROL_FLOAT radius_delta;
+		struct VALUE_CONTROL_U8 colour_delta_a;
+		struct VALUE_CONTROL_U8 colour_delta_r;
+		struct VALUE_CONTROL_U8 colour_delta_g;
+		struct VALUE_CONTROL_U8 colour_delta_b;
+		uint32_t lifeLoop;
+		struct VALUE_CONTROL_FLOAT length;
+		break;
+	case TRAILER:
+		float life_max;
+		struct STREAMER_EFFECT_DATA data;
+		break;
+	case LIGHT_VOLUME:
+		char crash_now[99999999];
+		break;
+	case DAMAGE_SPHERE:
+		uint32_t a;
+		uint32_t b;
+		uint32_t c;
+		break;
+	default:
+		char crash_now[99999999];
+	}
+};
+
+struct Object
+{
+	enum MESH_TYPE
+	{
+		MESH,
+		EMITTER,
+		UNUSED_SPRITE,
+		HIERARCHY,
+		TRIGGER,
+		SPOT_EFFECT
+	};
+	enum MESH_TYPE meshType;
+	uint32_t actorID;
+
+	float radius;
+	float scale;
+	struct Vector3 position;
+	struct Vector3 rotation;
+
+	uint32_t some_type;
+	uint32_t unk;
+
+	struct ObjectData(uint32_t& type)
+	{
+		uint32_t read_type;
+		type = read_type;
+		switch (type)
+		{
+		case 2: //OBJECT ANIM
+		{
+			struct WP_ANIM wpAnim;
+			break;
+		}
+		case 3: //TRIGGER
+		{
+			uint32_t s1;
+			uint32_t s2;
+			uint32_t arr[s2];
+			break;
+		}
+		case 8:
+		{
+			struct OBJECT_PROPERTIES properties;
+			break;
+		}
+		case 14: //POSITION_SOURCE_TARGET
+		{
+			struct Vector3 source_position;
+			struct Vector3 target_position;
+			break;
+		}
+		case 15: //EMITTER deflection plane?
+		{
+			struct Vector3 v;
+			uint32_t a;
+			break;
+		}
+		case 18: //TEXTURE_SCALES::Load (only in retail)
+		{
+			uint32_t numTextureScales;
+			struct TextureScale
+			{
+				struct Vector3 a;
+				struct Vector3 b;
+				struct Vector3 c;
+			};
+			struct TextureScale ts[numTextureScales];
+			break;
+		}
+		default:
+			break;
+		}
+	};
+	struct ObjectData od[0]; // we don't know the size yet
+	local uint32_t type = 1; // so that we enter the while-loop
+	while (type)
+		ArrayExtend(od, 1, type);
+};
+
+struct EDNTexture
+{
+	uint32_t num_frames;
+	struct Frame frames[num_frames];
+
+	enum <uint16_t> Usage
+	{
+		NONE,
+		DIFFUSE,
+		LIGHT,
+		BUMP,
+		GLOSS,
+		ENVIRONMENT_MAP,
+		SPRITE,
+		EMISSIVE,
+		TEXT,
+		IMAGE
+	};
+	
+	if (num_frames > 0)
+	{
+		enum Usage usage;
+		bool is_transparent;
+		bool allow_mipmaps;
+		bool is_emissive;
+	}
+};
+
+struct EDNFile
+{
+	struct Header header;
+	
+	FSkip(1);											// no idea what this is, it is skipped by the game anyway
+	
+	uint32_t num_drawables;
+	int32_t drawables[num_drawables];
+	uint32_t num_ai_networks;
+	struct WP_ANIM ai_networks[num_ai_networks];
+
+	Printf("Reading lights...\n");
+	uint32_t num_lights;
+	struct Light lights[num_lights];
+
+	uint32_t num_objects;								// this is used later on
+
+	Printf("Reading rooms...\n");
+	uint32_t num_rooms;
+	struct Room rooms[num_rooms];
+	uint32_t num_reflected_rooms;
+//	struct Room reflected_rooms[num_reflected_rooms];	// fake flipped rooms rendered by mirror surfaces
+
+	struct Color32 fog_color;
+
+	Printf("Reading meshes...\n");
+	uint32_t num_meshes;
+	struct Mesh meshes[num_meshes];
+	
+	Printf("Reading emitters...\n");
+	uint32_t num_emitters;
+	struct Emitter emitters[num_emitters];
+	
+	Printf("Reading entities...\n");
+	uint32_t num_entities;
+	struct Entity entities[num_entities];
+
+	Printf("Reading objects...\n");
+	struct Object objects[num_objects];
+
+	Printf("Reading Actor WAD...\n");
+	struct ActorWad actor_wad;
+
+	// === textures & materials ===
+	Printf("Reading world tex&mat...\n");
+	uint32_t num_system_textures;						// usually 5
+	uint32_t num_textures;								// usually 2048 (fixed slots)
+	struct EDNTexture textures[num_textures];
+	uint32_t num_surface_materials;
+	struct SurfaceMaterial surface_materials[num_surface_materials];
+	uint32_t num_surface_properties;
+	struct SurfaceProperty surface_properties[num_surface_properties];
+
+	struct THING(int32_t& thing)
+	{
+		int32_t read_thing;
+		thing = read_thing;
+		if (thing >= 0)
+		{
+			uint32_t count;
+			struct SMTH
+			{
+				uint32_t position;
+			};
+			struct SMTH arr[count];
+		}
+	};
+	struct THING ts[0]; // we don't know the size yet
+	local int32_t thing = 1; // so that we enter the while-loop
+	while (thing >= 0)
+		ArrayExtend(ts, 1, thing);
+	
+	uint32_t k;
+	
+	// === level-specific dialogue strings ===
+	struct DialogueString
+	{
+		uint32_t length;
+		char str[length];
+		uint32_t id;
+	};
+	uint32_t num_dialogue_strings;						// often empty since Core moved them to separate EDT file
+	struct DialogueString dialogues[num_dialogue_strings];
+	
+	// === additional metadata ===
+	bool has_metadata;
+	if (has_metadata)
+	{
+		bool has_sound_file;
+		if (has_sound_file)
+			char eds_file_path[259];					// file name of the corresponding sound bank
+		else
+		{
+			struct DevStrings
+			{
+				uint16_t length;
+				char string[length];
+			};
+			uint32_t num_dev_strings;
+			struct DevStrings devstrings[num_dev_strings];
+		}
+	}
+
+	// the end, *whew* :)
+};
+struct EDNFile edn_file;

--- a/templates/core/edn_decompression/build_win32.cmd
+++ b/templates/core/edn_decompression/build_win32.cmd
@@ -1,0 +1,3 @@
+nasm -f win32 lzjat_decode.s -o lzjat_decode.o
+cc -std=c99 -c main.c -O2 -Wpedantic
+cc lzjat_decode.o main.o -o main.exe

--- a/templates/core/edn_decompression/lzjat_decode.s
+++ b/templates/core/edn_decompression/lzjat_decode.s
@@ -1,0 +1,195 @@
+;	LZJAT Decompression Code
+;	Copyright (c) Alan Moczulski 2024
+;
+;	Assemble this file using the following command in NASM:
+;		nasm lzjat_decode.asm -o lzjat_decode.o [-f elf32 OR -f win32]
+
+section .data
+	aNewFlagsFlagpo db "new flags flagPos %d flags %x",0xa,0
+	aNormInputIndex db "norm input index %d flags %x c %d",0xa,0
+	aLPIndex0DLDPD db "l+p index0 %d l %d p %d",0xa,0
+
+section .text
+; int __cdecl lzjat_decode(char *compressed, char *uncompressed, int *size, int original_size)
+global _lzjat_decode
+; we use printf to print some useful information during decoding
+extern _printf
+
+; constants for stack offsets
+var_418         EQU -418h
+var_414         EQU -414h
+var_410         EQU -410h
+var_40C         EQU -40Ch
+var_408         EQU -408h
+var_404         EQU -404h
+table           EQU -400h
+compressed      EQU 4
+uncompressed    EQU 8
+size            EQU 0Ch
+original_size   EQU 10h
+
+_lzjat_decode:
+	sub     esp, 418h						; allocate space for local variables
+	push    ebx
+	push    ebp
+	mov     ebp, [esp+420h+compressed]
+	push    esi
+	xor     ebx, ebx
+	push    edi
+	mov     edi, [esp+428h+uncompressed]
+	mov     [esp+428h+var_418], ebx
+	mov     [esp+428h+var_410], ebx
+	mov     [esp+428h+var_414], ebx
+	jmp     short loc_539A1C
+; ---------------------------------------------------------------------------
+
+loc_539A18:
+	mov     ebx, [esp+428h+var_408]
+
+loc_539A1C:
+	mov     eax, [esp+428h+var_410]
+	shr     eax, 1
+	test    ah, 0FFh
+	mov     [esp+428h+var_410], eax
+	jnz     short loc_539A59
+	mov     ecx, [esp+428h+var_414]
+	xor     eax, eax
+	mov     al, [ebp+0]
+	or      ah, 0FFh
+	test    ecx, ecx
+	mov     [esp+428h+var_410], eax
+	jz      short loc_539A57
+	push    eax
+	push    ebx
+	push    aNewFlagsFlagpo					; "new flags flagPos %d flags %x\n"
+	call    _printf
+	mov     eax, [esp+434h+var_414]
+	add     esp, 0Ch						; clean stack after printf call
+	dec     eax
+	mov     [esp+428h+var_414], eax
+
+loc_539A57:
+	inc     ebp
+	inc     ebx
+
+loc_539A59:
+	mov     eax, [esp+428h+var_410]
+	mov     ecx, eax
+	and     ecx, 1
+	cmp     cl, 1
+	jnz     short loc_539ACE
+	mov     ecx, [esp+428h+var_414]
+	mov     dl, [ebp+0]
+	test    ecx, ecx
+	mov     byte [esp+428h+var_404], dl
+	jz      short loc_539A90
+	mov     ecx, [esp+428h+var_404]
+	and     ecx, 0FFh
+	push    ecx
+	push    eax
+	push    ebx
+	push    aNormInputIndex					; "norm input index %d flags %x c %d\n"
+	call    _printf
+	add     esp, 10h						; clean stack after printf call
+
+loc_539A90:
+	mov     dl, byte [esp+428h+var_404]
+	mov     eax, [esp+428h+var_418]
+	mov     ecx, [esp+428h+original_size]
+	inc     ebp
+	inc     ebx
+	mov     [edi], dl
+	inc     edi
+	inc     eax
+	cmp     ecx, 0FFFFFFFFh
+	mov     [esp+428h+var_418], eax
+	jz      loc_539A1C
+	cmp     ecx, eax
+	jg      loc_539A1C
+
+loc_539ABA:
+	mov     ecx, [esp+428h+size]
+	pop     edi
+	pop     esi
+	pop     ebp
+	mov     [ecx], eax
+	pop     ebx
+	add     esp, 418h
+	retn
+; ---------------------------------------------------------------------------
+
+loc_539ACE:
+	mov     al, [ebp+0]
+	mov     dl, [ebp+1]
+	inc     ebp
+	mov     byte [esp+428h+var_40C], al
+	mov     esi, [esp+428h+var_40C]
+	mov     byte [esp+428h+var_40C], dl
+	mov     eax, [esp+428h+var_40C]
+	and     esi, 0FFh
+	and     eax, 0FFh
+	mov     ecx, ebx
+	mov     edx, eax
+	inc     ebx
+	shl     esi, 4
+	inc     ebp
+	inc     ebx
+	shr     edx, 4
+	or      esi, edx
+	mov     [esp+428h+var_408], ebx
+	jz      short loc_539B6F
+	and     eax, 0Fh
+	mov     ebx, eax
+	mov     eax, [esp+428h+var_414]
+	test    eax, eax
+	jz      short loc_539B22
+	push    esi
+	push    ebx
+	push    ecx
+	push    aLPIndex0DLDPD					; "l+p index0 %d l %d p %d\n"
+	call    _printf
+	add     esp, 10h						; clean stack after printf call
+
+loc_539B22:
+	mov     eax, edi
+	inc     ebx
+	sub     eax, esi
+	mov     esi, [esp+428h+uncompressed]
+	sub     eax, esi
+	xor     ecx, ecx
+	test    ebx, ebx
+	jl      loc_539A18
+	mov     edx, esi
+	add     edx, eax
+
+loc_539B3E:
+	mov     al, [edx+ecx]
+	mov     esi, [esp+428h+original_size]
+	mov     [esp+ecx+428h+table], al
+	mov     [edi], al
+	mov     eax, [esp+428h+var_418]
+	inc     edi
+	inc     eax
+	cmp     esi, 0FFFFFFFFh
+	mov     [esp+428h+var_418], eax
+	jz      short loc_539B65
+	cmp     esi, eax
+	jle     loc_539ABA
+
+loc_539B65:
+	inc     ecx
+	cmp     ecx, ebx
+	jle     short loc_539B3E
+	jmp     loc_539A18
+; ---------------------------------------------------------------------------
+
+loc_539B6F:
+	mov     edx, [esp+428h+size]
+	mov     eax, [esp+428h+var_418]
+	pop     edi
+	pop     esi
+	pop     ebp
+	mov     [edx], eax
+	pop     ebx
+	add     esp, 418h
+	retn

--- a/templates/core/edn_decompression/main.c
+++ b/templates/core/edn_decompression/main.c
@@ -1,0 +1,83 @@
+//	Project Eden EDN File Decompression Utility
+//	Copyright (c) Alan Moczulski 2024
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+
+// defined inside "lzjat_decode.s"
+extern int __cdecl lzjat_decode(char *compressed, char *uncompressed, int *size, int original_size);
+
+static unsigned int get_file_size(FILE* f)
+{
+	unsigned int current = ftell(f); // keep current position
+	fseek(f, 0, SEEK_END);
+	unsigned int size = ftell(f);
+	fseek(f, current, SEEK_SET); // set back to where we were
+	return size;
+}
+
+int main(int argc, char** argv)
+{
+	int retval = 0;
+	
+	// the user needs to specify 2 EDN files
+	// example usage: ./edn_decompress l9_scavenge.edn l9_scavenge_decompressed.edn
+	if (argc != 3)
+	{
+		fprintf(stdout, "Usage: %s <input EDN file> <output EDN file>\n", argv[0]);
+		return 1;
+	}
+
+	// open the specified file
+	const char* edn_file_path = argv[1];
+	FILE* f = fopen(edn_file_path, "rb");
+	if (!f)
+	{
+		fputs("Specified file cannot be read.", stdout);
+		return 1;
+	}
+
+	int magic;
+	fread(&magic, 4, 1, f);
+	if (magic == 'PMOC') // "COMP"
+	{
+		unsigned int original_size; // original decompressed file size
+		fread(&original_size, 4, 1, f);
+		assert(original_size < 32 * 1024 * 1024); // no EDN file is bigger that 32MiB once uncompressed
+		unsigned int compressed_size = get_file_size(f) - 8; // 8 is the size of the 2 previous vars we already read
+//		fprintf(stdout, "%u, %u\n", original_size, compressed_size);
+
+		// read whole compressed file into a buffer
+		char* compressed = malloc(compressed_size);
+		fread(compressed, compressed_size, 1, f);
+		
+		// allocate enough space and decompress into it
+		char* decompressed = malloc(original_size);
+		int dummy = original_size;
+		lzjat_decode(compressed, decompressed, &dummy, original_size);
+		
+		// write out the decompressed data to a file
+		FILE* fd = fopen("output.edn", "wb");
+		if (!fd)
+		{
+			fputs("Specified file cannot be read.", stdout);
+			return 1;
+		}
+		fwrite(decompressed, original_size, 1, fd);
+		fclose(fd);
+
+		free(decompressed);
+		free(compressed);
+		fputs("File decompressed successfully.", stdout);
+	}
+	else
+	{
+		fputs("Specified file is not compressed.", stdout);
+		retval = 2;
+	}
+
+	fclose(f);
+	return retval;
+}


### PR DESCRIPTION
This PR adds support for 2 file formats used by Core Design exclusively for Project Eden (2001) in the form of REHex binary template files. A decompression utility is also provided for compressed EDN files, including its C and x86 source code.

The binary template files as well as the decompression utility have been tested on a variety of EDN files. No issues so far, except for long REHex parsing times (1 hour is common).

Thank you for considering my contribution. Please feel free to criticise and let me know if something needs improvement 🥇.

Here are some proof screens:
![rehex_screen_2](https://github.com/hogsy/formats/assets/94763702/348942d5-c18f-4836-a630-db6cfde91d03)
![rehex_screen](https://github.com/hogsy/formats/assets/94763702/1ebd5e9c-fe12-48f0-8387-2aae58f56b56)

